### PR TITLE
robots.txt で不完全なロゴ画像を検索で表示されないようにする

### DIFF
--- a/docs/robots.txt
+++ b/docs/robots.txt
@@ -1,0 +1,4 @@
+User-Agent:*
+Disallow:/assets/img/logo/
+
+Sitemap:https://wwwinternet.club/sitemap.xml


### PR DESCRIPTION
:sparkles: 